### PR TITLE
Stereo reverb

### DIFF
--- a/CloudSeed/AllpassDiffuser.h
+++ b/CloudSeed/AllpassDiffuser.h
@@ -23,7 +23,7 @@ namespace CloudSeed
 		vector<float> seedValues;
 		int seed;
 		float crossSeed;
-		
+
 	public:
 		int Stages;
 
@@ -95,7 +95,7 @@ namespace CloudSeed
 			return filters[Stages - 1]->GetOutput();
 		}
 
-		
+
 		void SetDelay(int delaySamples)
 		{
 			delay = delaySamples;
@@ -110,7 +110,7 @@ namespace CloudSeed
 
 		void SetModAmount(float amount)
 		{
-			for (int i = 0; i < filters.size(); i++)
+			for (size_t i = 0; i < filters.size(); i++)
 			{
 				filters[i]->ModAmount = amount * (0.85 + 0.3 * seedValues[MaxStageCount + i]);
 			}

--- a/CloudSeed/DelayLine.h
+++ b/CloudSeed/DelayLine.h
@@ -34,11 +34,11 @@ namespace CloudSeed
 		bool LateStageTap;
 
 		DelayLine(int bufferSize, int samplerate)
-			: lowPass(samplerate)
-			, delay(bufferSize, samplerate * 2, 10000) // 2 second buffer, to prevent buffer overflow with modulation and randomness added (Which may increase effective delay)
+			: delay(bufferSize, samplerate * 2, 10000) // 2 second buffer, to prevent buffer overflow with modulation and randomness added (Which may increase effective delay)
 			, diffuser(samplerate, 150) // 150ms buffer
 			, lowShelf(AudioLib::Biquad::FilterType::LowShelf, samplerate)
 			, highShelf(AudioLib::Biquad::FilterType::HighShelf, samplerate)
+			, lowPass(samplerate)
 		{
 			this->bufferSize = bufferSize;
 			tempBuffer = new float[bufferSize];

--- a/CloudSeed/Exports.cpp
+++ b/CloudSeed/Exports.cpp
@@ -28,12 +28,12 @@ extern "C"
 
 	int GetSamplerate(ReverbController* item)
 	{
-		return item->GetSamplerate();
+		return item->GetSampleRate();
 	}
 
 	void SetSamplerate(ReverbController* item, int samplerate)
 	{
-		return item->SetSamplerate(samplerate);
+		return item->SetSampleRate(samplerate);
 	}
 
 	int GetParameterCount(ReverbController* item)

--- a/CloudSeed/MultitapDiffuser.h
+++ b/CloudSeed/MultitapDiffuser.h
@@ -29,7 +29,7 @@ namespace CloudSeed
 		vector<float> seedValues;
 		int seed;
 		float crossSeed;
-		int count;
+		size_t count;
 		float length;
 		float gain;
 		float decay;
@@ -174,14 +174,13 @@ namespace CloudSeed
 			auto scaleLength = length / sumLengths;
 			newTapPosition[0] = 0;
 
-			for (int i = 1; i < count; i++)
+			for (size_t i = 1; i < count; i++)
 			{
 				newTapPosition[i] = newTapPosition[i - 1] + (int)(tapData[i] * scaleLength);
 			}
 
-			float sumGains = 0.0;
 			float lastTapPos = newTapPosition[count - 1];
-			for (int i = 0; i < count; i++)
+			for (size_t i = 0; i < count; i++)
 			{
 				// when decay set to 0, there is no decay, when set to 1, the gain at the last sample is 0.01 = -40dB
 				auto g = std::pow(10, -decay * 2 * newTapPosition[i] / (float)(lastTapPos + 1));

--- a/CloudSeed/ReverbChannel.h
+++ b/CloudSeed/ReverbChannel.h
@@ -33,11 +33,6 @@ namespace CloudSeed
 	class ReverbChannel
 	{
 	private:
-                // IMPORTANT: CHANGE "TotalLineCount" FOR DAISY SEED HARDWARE
-                //            Original CloudSeed plugin uses 8 Delay Lines, or 12 delay lines?
-                //            Adjusted to 2 to use with Stereo on DaisySeed hardware
-		static const int TotalLineCount = 2;
-
 		map<Parameter, float> parameters;
 		int samplerate;
 		int bufferSize;
@@ -70,7 +65,7 @@ namespace CloudSeed
 
 	public:
 
-		ReverbChannel(int bufferSize, int samplerate, ChannelLR leftOrRight)
+		ReverbChannel(int bufferSize, int samplerate, ChannelLR leftOrRight, int totalLineCount)
 			: preDelay(bufferSize, (int)(samplerate * 1.0), 100) // 1 second delay buffer
 			, multitap(samplerate) // use samplerate = 1 second delay buffer
 			, highPass(samplerate)
@@ -79,7 +74,7 @@ namespace CloudSeed
 		{
 			this->channelLr = leftOrRight;
 
-			for (int i = 0; i < TotalLineCount; i++)
+			for (int i = 0; i < totalLineCount; i++)
 				lines.push_back(new (custom_pool_allocate(sizeof(DelayLine)))DelayLine(bufferSize, samplerate));
 
 			this->bufferSize = bufferSize;
@@ -88,7 +83,7 @@ namespace CloudSeed
 				this->parameters[static_cast<Parameter>(value)] = 0.0;
 
 			crossSeed = 0.0;
-			lineCount = TotalLineCount;
+			lineCount = totalLineCount;
 			diffuser.SetInterpolationEnabled(true);
 			highPass.SetCutoffHz(20);
 			lowPass.SetCutoffHz(20000);

--- a/CloudSeed/ReverbChannel.h
+++ b/CloudSeed/ReverbChannel.h
@@ -42,8 +42,8 @@ namespace CloudSeed
 		AllpassDiffuser diffuser;
 		vector<DelayLine*> lines;
 		AudioLib::ShaRandom rand;
-		AudioLib::Hp1 highPass;
 		AudioLib::Lp1 lowPass;
+		AudioLib::Hp1 highPass;
 		float* tempBuffer;
 		float* lineOutBuffer;
 		float* outBuffer;
@@ -68,9 +68,9 @@ namespace CloudSeed
 		ReverbChannel(int bufferSize, int samplerate, ChannelLR leftOrRight, int totalLineCount)
 			: preDelay(bufferSize, (int)(samplerate * 1.0), 100) // 1 second delay buffer
 			, multitap(samplerate) // use samplerate = 1 second delay buffer
-			, highPass(samplerate)
-			, lowPass(samplerate)
 			, diffuser(samplerate, 150) // 150ms buffer, to allow for 100ms + modulation time
+			, lowPass(samplerate)
+			, highPass(samplerate)
 		{
 			this->channelLr = leftOrRight;
 
@@ -116,7 +116,7 @@ namespace CloudSeed
 			highPass.SetSamplerate(samplerate);
 			lowPass.SetSamplerate(samplerate);
 
-			for (int i = 0; i < lines.size(); i++)
+			for (size_t i = 0; i < lines.size(); i++)
 			{
 				lines[i]->SetSamplerate(samplerate);
 			}
@@ -329,6 +329,8 @@ namespace CloudSeed
 				for (auto line : lines)
 					line->SetInterpolationEnabled(value >= 0.5);
 				break;
+            default:
+                break;
 			}
 		}
 
@@ -472,7 +474,7 @@ namespace CloudSeed
 
 		void UpdatePostDiffusion()
 		{
-			for (int i = 0; i < lines.size(); i++)
+			for (size_t i = 0; i < lines.size(); i++)
 				lines[i]->SetDiffuserSeed(((long long)postDiffusionSeed) * (i + 1), crossSeed);
 		}
 

--- a/CloudSeed/ReverbChannel.h
+++ b/CloudSeed/ReverbChannel.h
@@ -35,9 +35,8 @@ namespace CloudSeed
 	private:
                 // IMPORTANT: CHANGE "TotalLineCount" FOR DAISY SEED HARDWARE
                 //            Original CloudSeed plugin uses 8 Delay Lines, or 12 delay lines?
-                //            DaisyCloudSeed adjusted to 2 to use with Stereo on DaisyPatch hardware (otherwise causes buffer underruns for most presets (except ChorusDelay)
-                //            4/26/2023 GuitarML fork of DaisyCloudSeed uses 4, able to increase for Mono Only Terrarium platform (mono guitar pedal using Daisy Seed)
-		static const int TotalLineCount = 5;  
+                //            Adjusted to 2 to use with Stereo on DaisySeed hardware
+		static const int TotalLineCount = 2;
 
 		map<Parameter, float> parameters;
 		int samplerate;
@@ -70,7 +69,7 @@ namespace CloudSeed
 		ChannelLR channelLr;
 
 	public:
-		
+
 		ReverbChannel(int bufferSize, int samplerate, ChannelLR leftOrRight)
 			: preDelay(bufferSize, (int)(samplerate * 1.0), 100) // 1 second delay buffer
 			, multitap(samplerate) // use samplerate = 1 second delay buffer
@@ -457,7 +456,7 @@ namespace CloudSeed
 			{
 				auto modAmount = lineModAmount * (0.7 + 0.3 * delayLineSeeds[i + count]);
 				auto modRate = lineModRate * (0.7 + 0.3 * delayLineSeeds[i + 2 * count]) / samplerate;
-				
+
 				auto delaySamples = (0.5 + 1.0 * delayLineSeeds[i]) * lineDelaySamples;
 				if (delaySamples < modAmount + 2) // when the delay is set really short, and the modulation is very high
 					delaySamples = modAmount + 2; // the mod could actually take the delay time negative, prevent that! -- provide 2 extra sample as margin of safety

--- a/CloudSeed/ReverbController.h
+++ b/CloudSeed/ReverbController.h
@@ -24,29 +24,20 @@ namespace CloudSeed
 		int samplerate;
 
 		ReverbChannel channelL;
-		//ReverbChannel channelR;
+		ReverbChannel channelR;
 		float leftChannelIn[bufferSize];
-		//float rightChannelIn[bufferSize];
+		float rightChannelIn[bufferSize];
 		float leftLineBuffer[bufferSize];
-		//float rightLineBuffer[bufferSize];
+		float rightLineBuffer[bufferSize];
 		float parameters[(int)Parameter::Count];
 
 	public:
 		ReverbController(int samplerate)
 			: channelL(bufferSize, samplerate, ChannelLR::Left)
-			//, channelR(bufferSize, samplerate, ChannelLR::Right)
+			, channelR(bufferSize, samplerate, ChannelLR::Right)
 		{
 			this->samplerate = samplerate;
-			initFactoryChorus();
-			//initFactoryDullEchos();
-			//initFactoryHyperplane();
-			//initFactoryMediumSpace();
-			//initFactoryNoiseInTheHallway();
-			//initFactoryRubiKaFields();
-			//initFactorySmallRoom();
-			//initFactory90sAreBack();
-			//initFactoryThroughTheLookingGlass();
-
+            initFactoryChorus();
 		}
 
 		void initFactoryChorus()
@@ -107,7 +98,6 @@ namespace CloudSeed
 
 		}
 
-
 		void initFactoryDullEchos()
 		{
 			//parameters from Dull Echos in
@@ -165,7 +155,6 @@ namespace CloudSeed
 			}
 
 		}
-
 
 		void initFactoryHyperplane()
 		{
@@ -399,7 +388,6 @@ namespace CloudSeed
 
 		}
 
-
 		void initFactorySmallRoom()
 		{
 			//parameters from Small Room in
@@ -581,7 +569,7 @@ namespace CloudSeed
 			this->samplerate = samplerate;
 
 			channelL.SetSamplerate(samplerate);
-			//channelR.SetSamplerate(samplerate);
+			channelR.SetSamplerate(samplerate);
 		}
 
 		int GetParameterCount()
@@ -617,7 +605,7 @@ namespace CloudSeed
 			case Parameter::DiffusionFeedback:         return P(Parameter::DiffusionFeedback);
 
 				// Late
-			case Parameter::LineCount:                 return 1 + (int)(P(Parameter::LineCount) * 4.999);   // Change from 11.999 to 4.999
+			case Parameter::LineCount:                 return 1 + (int)(P(Parameter::LineCount) * 1.999);   // Change from 11.999 to 1.999
 			case Parameter::LineDelay:                 return (int)(20.0 + ValueTables::Get(P(Parameter::LineDelay), ValueTables::Response2Dec) * 980);
 			case Parameter::LineDecay:                 return 0.05 + ValueTables::Get(P(Parameter::LineDecay), ValueTables::Response3Dec) * 59.95;
 
@@ -678,7 +666,7 @@ namespace CloudSeed
 			auto scaled = GetScaledParameter(param);
 
 			channelL.SetParameter(param, scaled);
-			//channelR.SetParameter(param, scaled);
+			channelR.SetParameter(param, scaled);
 		}
 
 
@@ -686,32 +674,30 @@ namespace CloudSeed
 		void ClearBuffers()
 		{
 			channelL.ClearBuffers();
-			//channelR.ClearBuffers();
+			channelR.ClearBuffers();
 		}
 
 		void Process(float* input, float* output, int bufferSize)
 		{
 			auto len = bufferSize;
-			//auto cm = GetScaledParameter(Parameter::InputMix) * 0.5; // Removing L/R mixing for Mono Terrarium
-			//auto cmi = (1 - cm);                                     // Removing L/R mixing for Mono Terrarium
+			auto cm = GetScaledParameter(Parameter::InputMix) * 0.5;
+			auto cmi = (1 - cm);
 
 			for (int i = 0; i < len; i++)
 			{
-				//leftChannelIn[i] = input[i *2] // * cmi + input[i*2+1] * cm;
-                leftChannelIn[i] = input[i];                        // Removing L/R mixing for Mono Terrarium
-				//rightChannelIn[i] = input[i*2+1] * cmi + input[i*2] * cm;
+				leftChannelIn[i] = input[i*2] * cmi + input[i*2+1] * cm;
+				rightChannelIn[i] = input[i*2+1] * cmi + input[i*2] * cm;
 			}
 
 			channelL.Process(leftChannelIn, len);
-			//channelR.Process(rightChannelIn, len);
+			channelR.Process(rightChannelIn, len);
 			auto leftOut = channelL.GetOutput();
-			//auto rightOut = channelR.GetOutput();
+			auto rightOut = channelR.GetOutput();
 
 			for (int i = 0; i < len; i++)
 			{
-				//output[i*2] = leftOut[i];
-                output[i] = leftOut[i];
-				//output[i*2+1] = rightOut[i];
+				output[i*2] = leftOut[i];
+				output[i*2+1] = rightOut[i];
 			}
 		}
 

--- a/src/cloudseed.cpp
+++ b/src/cloudseed.cpp
@@ -167,7 +167,7 @@ static void AudioCallback(AudioHandle::InputBuffer  in,
     }
 
     if(!bypassSwitch.value) {
-        reverb->Process(ins, outs, blockSize);
+        reverb->Process(ins, outs);
         for (size_t i = 0; i < size; i++)
         {
             out[0][i] = outs[i*2] * 1.2;  // Slight overall volume boost at 1.2
@@ -225,6 +225,7 @@ int main(void)
 
     currentPresetIndex = 0;
     reverb = new CloudSeed::ReverbController(sampleRate);
+    reverb->InitStereo();
     setPreset(currentPresetIndex);
 
     AdcInit();

--- a/src/cloudseed.cpp
+++ b/src/cloudseed.cpp
@@ -9,7 +9,7 @@
 #include "../../CloudSeed/AudioLib/ValueTables.h"
 #include "../../CloudSeed/AudioLib/MathDefs.h"
 
-#define PERFORMANCE_MONITOR 1
+// #define PERFORMANCE_MONITOR 1
 
 using namespace daisy;
 using namespace daisysp;
@@ -224,8 +224,7 @@ int main(void)
     CloudSeed::FastSin::Init();
 
     currentPresetIndex = 0;
-    reverb = new CloudSeed::ReverbController(sampleRate);
-    reverb->InitStereo();
+    reverb = new CloudSeed::ReverbController(sampleRate, CloudSeed::StereoMode::Stereo);
     setPreset(currentPresetIndex);
 
     AdcInit();

--- a/src/cloudseed.cpp
+++ b/src/cloudseed.cpp
@@ -10,6 +10,7 @@
 #include "../../CloudSeed/AudioLib/MathDefs.h"
 
 // #define PERFORMANCE_MONITOR 1
+// #define VERBOSE 1
 
 using namespace daisy;
 using namespace daisysp;
@@ -27,14 +28,12 @@ enum class Inputs: int {
 float currentValues[(int)Inputs::Count],
       previousValues[(int)Inputs::Count];
 
-struct GPIOPin {
+struct {
     daisy::Pin pin;
     GPIO gpio;
     bool value;
     bool previous;
-};
-GPIOPin presetCycleButton;
-GPIOPin bypassSwitch;
+} presetCycleButton, bypassButton, stereoSwitch;
 int currentPresetIndex;
 
 const size_t blockSize = 48;
@@ -108,6 +107,18 @@ void cyclePreset()
     setPreset(currentPresetIndex);
 }
 
+void changeReverbMode()
+{
+#ifdef VERBOSE
+    hw.PrintLine("Stereo mode %d", stereoSwitch.value);
+#endif
+    if (stereoSwitch.value)
+        reverb->setStereoMode(CloudSeed::StereoMode::Stereo);
+    else
+        reverb->setStereoMode(CloudSeed::StereoMode::Mono);
+    setPreset(currentPresetIndex);
+}
+
 void readAdcValues()
 {
     // TODO use a one pole filter to smooth those out (calling freq is sampleRate / blockSize)
@@ -135,11 +146,14 @@ void updateReverbParameters()
 
 void updateSwitches()
 {
+    stereoSwitch.previous = stereoSwitch.value;
+    stereoSwitch.value = stereoSwitch.gpio.Read();
+
     presetCycleButton.previous = presetCycleButton.value;
     presetCycleButton.value = presetCycleButton.gpio.Read();
 
-    bypassSwitch.previous = bypassSwitch.value;
-    bypassSwitch.value = bypassSwitch.gpio.Read();
+    bypassButton.previous = bypassButton.value;
+    bypassButton.value = bypassButton.gpio.Read();
 }
 
 // This runs at a fixed rate, to prepare audio samples
@@ -153,6 +167,10 @@ static void AudioCallback(AudioHandle::InputBuffer  in,
 
     updateReverbParameters();
     updateSwitches();
+    if (stereoSwitch.value != stereoSwitch.previous) // Rising or falling edge
+    {
+        changeReverbMode();
+    }
 
     for (size_t i = 0; i < size; i++)
     {
@@ -166,7 +184,7 @@ static void AudioCallback(AudioHandle::InputBuffer  in,
         cyclePreset();
     }
 
-    if(!bypassSwitch.value) {
+    if(!bypassButton.value) {
         reverb->Process(ins, outs);
         for (size_t i = 0; i < size; i++)
         {
@@ -200,13 +218,17 @@ void AdcInit()
 
 void GPIOInit()
 {
+    stereoSwitch.pin = daisy::seed::D28;
+    stereoSwitch.gpio = GPIO();
+    stereoSwitch.gpio.Init(stereoSwitch.pin, GPIO::Mode::INPUT, GPIO::Pull::PULLDOWN);
+
     presetCycleButton.pin = daisy::seed::D29;
     presetCycleButton.gpio = GPIO();
     presetCycleButton.gpio.Init(presetCycleButton.pin, GPIO::Mode::INPUT, GPIO::Pull::PULLDOWN);
 
-    bypassSwitch.pin = daisy::seed::D30;
-    bypassSwitch.gpio = GPIO();
-    bypassSwitch.gpio.Init(bypassSwitch.pin, GPIO::Mode::INPUT, GPIO::Pull::PULLDOWN);
+    bypassButton.pin = daisy::seed::D30;
+    bypassButton.gpio = GPIO();
+    bypassButton.gpio.Init(bypassButton.pin, GPIO::Mode::INPUT, GPIO::Pull::PULLDOWN);
 }
 
 int main(void)
@@ -215,8 +237,11 @@ int main(void)
     hw.SetAudioBlockSize(blockSize);
     float sampleRate = hw.AudioSampleRate();
 
-    #ifdef PERFORMANCE_MONITOR
+    #if defined(VERBOSE) || defined(PERFORMANCE_MONITOR)
     hw.StartLog();
+    #endif
+
+    #ifdef PERFORMANCE_MONITOR
     loadMeter.Init(sampleRate, blockSize);
     #endif
 
@@ -224,7 +249,7 @@ int main(void)
     CloudSeed::FastSin::Init();
 
     currentPresetIndex = 0;
-    reverb = new CloudSeed::ReverbController(sampleRate, CloudSeed::StereoMode::Stereo);
+    reverb = new CloudSeed::ReverbController(sampleRate, CloudSeed::StereoMode::Mono);
     setPreset(currentPresetIndex);
 
     AdcInit();

--- a/src/cloudseed.cpp
+++ b/src/cloudseed.cpp
@@ -38,8 +38,8 @@ GPIOPin bypassSwitch;
 int currentPresetIndex;
 
 const size_t blockSize = 48;
-float ins[blockSize];
-float outs[blockSize];
+float ins[blockSize*2];
+float outs[blockSize*2];
 
 #ifdef PERFORMANCE_MONITOR
 CpuLoadMeter loadMeter;
@@ -156,7 +156,8 @@ static void AudioCallback(AudioHandle::InputBuffer  in,
 
     for (size_t i = 0; i < size; i++)
     {
-        ins[i] = in[0][i];
+        ins[i*2] = in[0][i];
+        ins[i*2+1] = in[0][i];
     }
 
     // Cycle available models
@@ -166,15 +167,17 @@ static void AudioCallback(AudioHandle::InputBuffer  in,
     }
 
     if(!bypassSwitch.value) {
-        reverb->Process(ins, outs, 48);
+        reverb->Process(ins, outs, blockSize);
         for (size_t i = 0; i < size; i++)
         {
-            out[0][i] = outs[i] * 1.2;  // Slight overall volume boost at 1.2
+            out[0][i] = outs[i*2] * 1.2;  // Slight overall volume boost at 1.2
+            out[1][i] = outs[i*2+1] * 1.2;  // Slight overall volume boost at 1.2
         }
     } else {
         for (size_t i = 0; i < size; i++)
         {
             out[0][i] = in[0][i];
+            out[1][i] = in[0][i];
         }
     }
 


### PR DESCRIPTION
This PR adds support for stereo reverb and implements logic to switch between mono and stereo modes. This is done by modifying the CloudSeed library to support switching between two modes and exposing methods to do so.

Some light refactoring was also done to address warnings during build.